### PR TITLE
Setup AppConfiguration with a json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -393,3 +393,4 @@ Desktop.ini
 /Blue10CLI/out/clrjit.dll
 /Blue10CLI/out/clrcompression.dll
 /Blue10CLI/out/Blue10CLI.exe
+/Blue10CLI/AppConfiguration.json

--- a/Blue10CLI/Blue10CLI.csproj
+++ b/Blue10CLI/Blue10CLI.csproj
@@ -31,24 +31,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="api_key.auth">
+    <None Update="AppConfiguration.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="listVendors.csv">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="listVendors.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="listVendors.ssv">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="listVendors.tsv">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="listVendors.xml">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+
   </ItemGroup>
 
 </Project>

--- a/Blue10CLI/Helpers/AppConfiguration.cs
+++ b/Blue10CLI/Helpers/AppConfiguration.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.IO;
+using System.Text.Json;
+
+namespace Blue10CLI.Helpers
+{
+
+    public static class AppConfiguration
+    {
+        internal const string CONFIG_FILE = "AppConfiguration.json";
+
+        public static Values Values { get; set; } = new Values();
+
+        public static void GetSettings()
+        {
+            if (File.Exists(CONFIG_FILE))
+            {
+                try
+                {
+                    var fJsonFile = File.ReadAllText(CONFIG_FILE);
+                    if (string.IsNullOrWhiteSpace(fJsonFile))
+                    {
+                        Console.WriteLine("AppConfiguration.json file appears to be empty");
+                        return;
+                    }
+
+                    var fAppConfigration = JsonSerializer.Deserialize<Values>(fJsonFile);
+
+                    if (fAppConfigration != null)
+                        Values = fAppConfigration;
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine("Error reading configurations from AppConfiguration.json file: " + e);
+                    return;
+                }
+            }
+            else
+            {
+                var fStringJson = JsonSerializer.Serialize(Values);
+                File.WriteAllText(CONFIG_FILE, fStringJson);
+            }
+        }
+
+        public static bool SaveSettings()
+        {
+            try
+            {
+                var fStringJson = JsonSerializer.Serialize(Values);
+                File.WriteAllText(CONFIG_FILE, fStringJson);
+                return true;
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("Error writng configurations to AppConfiguration.json file: " + e);
+                return false;
+            }
+        }
+    }
+
+    public class Values
+    {
+        internal const string DEFAULT_BASEURL = "https://api.blue10.com/v2/";
+
+        public string? ApiKey { get; set; } = string.Empty;
+
+        private string? baseUrl = DEFAULT_BASEURL;
+        public string? BaseUrl
+        {
+            get { return baseUrl; }
+            set
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                    baseUrl = DEFAULT_BASEURL;
+                baseUrl = value;
+            }
+        }
+    }
+}

--- a/Blue10CLI/Services/WindowsCredentialService.cs
+++ b/Blue10CLI/Services/WindowsCredentialService.cs
@@ -1,0 +1,84 @@
+﻿using Blue10CLI.services;
+using Microsoft.Extensions.Logging;
+using System;
+
+namespace Blue10CLI.Services
+{
+    public class WindowsCredentialService
+    {
+        private readonly ILogger<WindowsCredentialService> _log;
+        internal const string BLUE10_API_KEY_TARGET = "Blue10ApiKey";
+
+        public string? GetApiKey()
+        {
+            try
+            {
+                //StorageSolution = EStorageSolution.WindowsCredentialsManagement;
+                // var cm = new Credential {Target = BLUE10_API_KEY_TARGET};
+                // cm.Load();
+                // cm?.Password;
+                return null;
+            }
+            catch (Exception e)
+            {
+                _log.LogError("Error retrieving apikey from Windows credentials manager", e);
+                return null;
+            }
+        }
+
+        public bool SetApiKey(string apiKey)
+        {
+            try
+            {
+                return SaveCredentialsInWindowsCredentialsManager(BLUE10_API_KEY_TARGET, apiKey);
+            }
+            catch (Exception e)
+            {
+                _log.LogError("Error writing api-key to Windows credential management", e);
+                return false;
+            }
+        }
+
+        public bool RemoveCredentials()
+        {
+            try
+            {
+                //var cm = new Credential {Target = BLUE10_API_KEY_TARGET};
+                //return cm.Delete();
+                return false;
+            }
+            catch (Exception e)
+            {
+                _log.LogError("Error removing credentials from windows credentials manager", e);
+                return false;
+            }
+        }
+
+        private static bool SaveCredentialsInWindowsCredentialsManager(string taget, string secret) => false;//new Credential {Target = BLUE10_API_KEY_TARGET, Password = secret, PersistanceType = PersistanceType.LocalComputer}.Save();
+
+        internal static string? EnsureApiKey()
+        {
+
+
+            Console.WriteLine("No Authentication file found, using Windows credentials management to store credentials");
+            try
+            {
+                var cm = BLUE10_API_KEY_TARGET;// new Credential {Target = BLUE10_API_KEY_TARGET};
+                                               // cm.Load();   
+                var apiKey = BLUE10_API_KEY_TARGET;
+                if (!string.IsNullOrWhiteSpace(apiKey)) return apiKey;
+                Console.WriteLine("Missing Blue10 API key, please insert here:");
+                var key = CredentialsService.ReadPassword();
+                SaveCredentialsInWindowsCredentialsManager(BLUE10_API_KEY_TARGET, key);
+                return key;
+            }
+            catch (Exception e)
+            {
+                //pass
+                Console.WriteLine("Could not initiate windows credentials manager");
+                return null;
+            }
+
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ Missing Blue10 API key, please insert here:
 ****************************************************************
 ````
 
-This will enter your API key in windows secrets manager under the key `Blue10ApiKey`
+This will enter your API key in the AppConfiguration.json file. 
+_Note that if the file doesn't exist it will be created_
 
 To check if the api that you have entered is valid run the following command:
 


### PR DESCRIPTION
New setup where there is aan AppConfiguration.json file where configuration can be put. Currently it can contain ApiKey and BaseUrl. The api_key.auth has been replaced by this new feature. BaseUrl is new and can be used to overwrite the default and connect to the Blue10 API on Dev for example.
The AppConfiguration.json file, if it doesn't exist already, will be created in the root folder of the executable