### PR TITLE
Vendor create error fix. 

### DIFF
--- a/Blue10CLI/Commands/Vendor/SubCommands/CreateVendorCommand.cs
+++ b/Blue10CLI/Commands/Vendor/SubCommands/CreateVendorCommand.cs
@@ -22,9 +22,9 @@ namespace Blue10CLI.commands
             Add(new Option<string>("--currency", "ISO 4217 three-letter currency code to set default currency for vendor") { IsRequired = true });
             Add(new Option<string[]>("--iban", "list of IBANs associated with this vendor") { IsRequired = true });
 
-            Add(new Option<string>(new[] { "-l", "--ledger" }, () => "Documents from this vendor will be routed to this ledger, leave empty to not associate"));
-            Add(new Option<string>(new[] { "-p", "--payment" }, () => "Documents from this vendor will be associated with this payment term, leave empty to not associate"));
-            Add(new Option<string>(new[] { "-v", "--vat" }, () => "Documents from this vendor will be associated with this VAT code, leave empty to not associate"));
+            Add(new Option<string>(new[] { "-l", "--ledger" }, () => string.Empty, "Documents from this vendor will be routed to this ledger, leave empty to not associate"));
+            Add(new Option<string>(new[] { "-p", "--payment" }, () => string.Empty, "Documents from this vendor will be associated with this payment term, leave empty to not associate"));
+            Add(new Option<string>(new[] { "-v", "--vat" }, () => string.Empty, "Documents from this vendor will be associated with this VAT code, leave empty to not associate"));
             //Add(new Option<bool>(new []{"-b","--blocked"}, () => false, "Block vendor upon creation, default false"));
 
             Add(new Option<EFormatType>(new[] { "-f", "--format" }, () => EFormatType.JSON, "Output format."));

--- a/Blue10CLI/services/VendorService.cs
+++ b/Blue10CLI/services/VendorService.cs
@@ -61,7 +61,8 @@ namespace Blue10CLI.services
             };
 
             var fVendorResultModel = await TryVendorTask(_blue10.AddVendorAsync(fCreateVendor));
-            _logger.LogError(fVendorResultModel.ErrorMessage);
+            if (!string.IsNullOrEmpty(fVendorResultModel.ErrorMessage))
+                _logger.LogError(fVendorResultModel.ErrorMessage);
             return fVendorResultModel.Object;
         }
 


### PR DESCRIPTION
In Vendor Create command some parameters use as default value the description. Now changed to string.Empty.
In vendor service, the create vendor function always logged error. Now checks errormessage if its null or empty.